### PR TITLE
Convergence checks

### DIFF
--- a/defSim/tests/test_convergence.py
+++ b/defSim/tests/test_convergence.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+from defSim.Simulation import Simulation
+from defSim.tools.ConvergenceChecks import OpinionDistanceConvergenceCheck
+
+class TestConvergence(TestCase):
+    simulation = Simulation(attributes_initializer="random_continuous",
+                            influence_function="bounded_confidence",
+                            dissimilarity_measure="euclidean",
+                            communication_regime="one-to-many",
+                            parameter_dict = {'confidence_bound': 0.5})
+
+    def test_max_iterations(self):
+        self.simulation.max_iterations = 10
+        self.simulation.stop_condition = 'max_iteration'
+
+        results = self.simulation.run_simulation()
+        print(results)
+
+    def test_pragmatic_convergence(self):
+        self.simulation.max_iterations = 4000
+        self.simulation.stop_condition = 'pragmatic_convergence'
+        results = self.simulation.run_simulation()
+        print(results)
+        assert(results['Ticks'][0] < self.simulation.max_iterations)
+
+    def test_opinion_distance_convergence(self):
+        self.simulation.max_iterations = 4000
+        self.simulation.stop_condition = 'strict_convergence'
+        self.simulation.parameter_dict['threshold'] = 0.5
+        results = self.simulation.run_simulation()
+        print(results)
+        assert(results['Ticks'][0] < self.simulation.max_iterations)
+
+    def test_convergence_instance(self):
+        self.simulation.max_iterations = 4000
+        self.simulation.stop_condition = OpinionDistanceConvergenceCheck(threshold = 0.5)
+        self.simulation.parameter_dict = {'confidence_bound': 0.5}
+        results = self.simulation.run_simulation()
+        print(results)
+        assert(results['Ticks'][0] < self.simulation.max_iterations)                    
+

--- a/defSim/tools/ConvergenceChecks.py
+++ b/defSim/tools/ConvergenceChecks.py
@@ -1,3 +1,4 @@
+from defSim.tools import NetworkDistanceUpdater
 from abc import ABC, abstractmethod
 import networkx as nx
 import networkx.algorithms.isomorphism as iso
@@ -10,7 +11,7 @@ class ConvergenceCheck(ABC):
     """
 
     @abstractmethod
-    def check_convergence(network: nx.Graph, **kwargs) -> bool:
+    def check_convergence(self, network: nx.Graph, **kwargs) -> bool:
         """
         This method receives a NetworkX object and returns whether the simulation has converged or not.
 
@@ -34,7 +35,7 @@ class PragmaticConvergenceCheck(ConvergenceCheck):
         all_attributes = initial_network.nodes[1].keys()
         self._node_matcher = iso.categorical_node_match(all_attributes, [0 for i in range(len(all_attributes))])                
 
-    def check_convergence(network: nx.Graph, **kwargs) -> bool:
+    def check_convergence(self, network: nx.Graph, **kwargs) -> bool:
         """
         This method receives a NetworkX object checks whether all attributes and the network structure
         are identical to the stored network from the previous call.
@@ -44,7 +45,7 @@ class PragmaticConvergenceCheck(ConvergenceCheck):
         :returns: True if no attributes changed and network structure has not changed, else False. 
         """            
 
-        if nx.is_isomorphic(self.network, self._previous_network, node_match=self._node_matcher):
+        if nx.is_isomorphic(network, self._previous_network, node_match=self._node_matcher):
             return True
         else:
             self._previous_network = network.copy()
@@ -63,7 +64,7 @@ class OpinionDistanceConvergenceCheck(ConvergenceCheck):
     def __init__(self, threshold):
         self.threshold = threshold   
 
-    def check_convergence(network: nx.Graph, **kwargs) -> bool:
+    def check_convergence(self, network: nx.Graph, **kwargs) -> bool:
         """
         This method receives a NetworkX object checks whether any pair of agents is within the specified
         opinion distance from each other, indicating that they could theoretically be influenced.
@@ -73,5 +74,5 @@ class OpinionDistanceConvergenceCheck(ConvergenceCheck):
         :returns: True if converged according to specified criteria, else False. 
         """
 
-        return not NetworkDistanceUpdater.check_dissimilarity(network, self.threshold):
+        return not NetworkDistanceUpdater.check_dissimilarity(network, self.threshold)
                      

--- a/defSim/tools/ConvergenceChecks.py
+++ b/defSim/tools/ConvergenceChecks.py
@@ -1,0 +1,77 @@
+from abc import ABC, abstractmethod
+import networkx as nx
+import networkx.algorithms.isomorphism as iso
+from typing import List
+
+class ConvergenceCheck(ABC):
+    """
+    This class is responsible for testing convergence.
+    Inherit from this class and implement the check_convergence method for each type of convergence check.
+    """
+
+    @abstractmethod
+    def check_convergence(network: nx.Graph, **kwargs) -> bool:
+        """
+        This method receives a NetworkX object and returns whether the simulation has converged or not.
+
+        :param network: A NetworkX graph object.
+
+        :returns: True if converged according to specified criteria, else False. 
+        """
+        pass
+
+
+class PragmaticConvergenceCheck(ConvergenceCheck):
+    """
+    Pragmatic convergence checks whether the structure of the network and all attributes are the same
+    as in the previous check. If that's the case, it is assumed that the simulation converged and it stops.
+
+    :param int=100 step_size: determines how often pragmatic convergence should be checked
+    """
+
+    def __init__(self, initial_network):
+        self._previous_network = initial_network
+        all_attributes = initial_network.nodes[1].keys()
+        self._node_matcher = iso.categorical_node_match(all_attributes, [0 for i in range(len(all_attributes))])                
+
+    def check_convergence(network: nx.Graph, **kwargs) -> bool:
+        """
+        This method receives a NetworkX object checks whether all attributes and the network structure
+        are identical to the stored network from the previous call.
+
+        :param network: A NetworkX graph object.
+
+        :returns: True if no attributes changed and network structure has not changed, else False. 
+        """            
+
+        if nx.is_isomorphic(self.network, self._previous_network, node_match=self._node_matcher):
+            return True
+        else:
+            self._previous_network = network.copy()
+            return False
+
+
+class OpinionDistanceConvergenceCheck(ConvergenceCheck):
+    """
+    Here the convergence of the simulation is periodically checked by assessing the distance between each neighbor
+    in the network. Unless there is no single pair left that can theoretically influence each other, the simulation
+    continues.
+
+    :param float=0.0 threshold: A value between 0 and 1 that determines at what distance two agents can't influence each other anymore.
+    """
+
+    def __init__(self, threshold):
+        self.threshold = threshold   
+
+    def check_convergence(network: nx.Graph, **kwargs) -> bool:
+        """
+        This method receives a NetworkX object checks whether any pair of agents is within the specified
+        opinion distance from each other, indicating that they could theoretically be influenced.
+
+        :param network: A NetworkX graph object.
+
+        :returns: True if converged according to specified criteria, else False. 
+        """
+
+        return not NetworkDistanceUpdater.check_dissimilarity(network, self.threshold):
+                     

--- a/defSim/tools/NetworkDistanceUpdater.py
+++ b/defSim/tools/NetworkDistanceUpdater.py
@@ -32,4 +32,3 @@ def check_dissimilarity(network: nx.Graph, threshold: float):
     """
 
     return any(threshold < val < 1 for key, val in nx.get_edge_attributes(network, 'dist').items())
-    pass


### PR DESCRIPTION
Based on #23, implement convergence checks as classes (under `tools/ConvergenceChecks.py`). This opens the door to custom convergence checks (instances can now be passed) and to different types of strict convergence based on the influence function (e.g. the current implementation of strict convergence is not appropriate for weighted linear influence). 

Also includes tests. Changes in this branch should not break existing simulations.